### PR TITLE
Adapt backend for Vercel serverless deployment

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -1,0 +1,6 @@
+import serverless from 'serverless-http';
+import { createApp } from '../src/app';
+
+const app = createApp();
+
+export default serverless(app);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
+        "serverless-http": "^4.0.0",
         "socket.io": "^4.5.4",
         "zod": "^3.22.4"
       },
@@ -1699,6 +1700,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-4.0.0.tgz",
+      "integrity": "sha512-KKl9h1+VApX9y2vHsVMogf906UXBwO3FDYiWPzqS0mCjEEx4Sx91JrssbWA7RN43HBuxrtoh8MkocZPvjyGnLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/setprototypeof": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^8.2.1",
     "helmet": "^8.1.0",
+    "serverless-http": "^4.0.0",
     "socket.io": "^4.5.4",
     "zod": "^3.22.4"
   },

--- a/backend/src/api/agents.ts
+++ b/backend/src/api/agents.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { io } from '../index';
+import { emitHexUpdate } from '../realtime';
 
 const prisma = new PrismaClient();
 const router = Router();
@@ -38,7 +38,7 @@ router.post('/', async (req: Request, res: Response) => {
     });
 
     // Emit socket event
-    io.to('hex-updates').emit('agent-created', {
+    emitHexUpdate('agent-created', {
       agent,
       message: `${agent.name} has joined the battlefield!`
     });

--- a/backend/src/api/gangs.ts
+++ b/backend/src/api/gangs.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
-import { io } from '../index';
+import { emitHexUpdate } from '../realtime';
 import { generateGangLogo } from '../utils/gangLogo';
 import { getGangColor } from '../utils/gangColor';
 
@@ -150,7 +150,7 @@ router.post('/create', async (req: Request, res: Response) => {
     });
 
     // Emit socket event
-    io.to('hex-updates').emit('gang-created', { gang });
+    emitHexUpdate('gang-created', { gang });
 
     res.json({
       success: true,
@@ -233,7 +233,7 @@ router.post('/join', async (req: Request, res: Response) => {
     });
 
     // Emit socket event
-    io.to('hex-updates').emit('gang-joined', { agentId, gangId });
+    emitHexUpdate('gang-joined', { agentId, gangId });
 
     res.json({
       success: true,

--- a/backend/src/api/hexes.ts
+++ b/backend/src/api/hexes.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { z } from 'zod';
-import { io } from '../index';
+import { emitHexUpdate } from '../realtime';
 import { validateAnswerWithAI } from '../services/aiProvider';
 import { getGangColor } from '../utils/gangColor';
 import prizePoolService from '../services/prizePool';
@@ -338,7 +338,7 @@ router.post('/claim', async (req: Request, res: Response) => {
     });
 
     // Emit socket event
-    io.to('hex-updates').emit('hex-claimed', {
+    emitHexUpdate('hex-claimed', {
       hex,
       agentScore: updatedAgent.score
     });
@@ -509,7 +509,7 @@ router.post('/challenge', async (req: Request, res: Response) => {
       });
 
       // Emit socket event
-      io.to('hex-updates').emit('hex-stolen', {
+      emitHexUpdate('hex-stolen', {
         hex: updatedHex,
         fromAgent: oldOwner.name,
         toAgent: newOwner.name,

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,129 @@
+// Load environment variables FIRST (before any other imports)
+import dotenv from 'dotenv';
+import path from 'path';
+
+// Explicitly load .env from backend directory
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+// Debug: Log environment (remove in production)
+console.log('[ENV] Loading from:', path.resolve(__dirname, '../.env'));
+console.log('[ENV] GLM_API_KEY exists:', !!process.env.GLM_API_KEY);
+
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
+import { PrismaClient } from '@prisma/client';
+import agentRoutes from './api/bots';
+import hexRoutes from './api/hexes';
+import leaderboardRoutes from './api/leaderboard';
+import statsRoutes from './api/stats';
+import waferRoutes from './api/wafers';
+import gangRoutes from './api/gangs';
+import walletRoutes from './api/wallet';
+import { checkAIProvider } from './services/aiProvider';
+
+const prisma = new PrismaClient();
+
+export function createApp() {
+  const app = express();
+
+  // CORS - Allow all origins for development
+  app.use(cors({
+    origin: '*',
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-OpenClaw-Bot', 'X-OpenClaw-Bot-Secret']
+  }));
+
+  // Security Middleware (configured to work with CORS)
+  app.use(helmet({
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+    crossOriginEmbedderPolicy: false,
+    contentSecurityPolicy: false
+  }));
+
+  // Rate Limiting
+  const limiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 100, // 100 requests per minute per IP
+    message: {
+      success: false,
+      error: 'Too many requests, please try again later.'
+    }
+  });
+
+  // Stricter rate limit for bot operations
+  const botLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 30, // 30 requests per minute for bot operations
+    message: {
+      success: false,
+      error: 'Bot rate limit exceeded. Please slow down.'
+    }
+  });
+
+  app.use(limiter);
+  app.use(express.json({ limit: '10mb' }));
+
+  // Health check (supports /health and /api/health for serverless)
+  const healthHandler = async (_req: express.Request, res: express.Response) => {
+    const stats = await prisma.agent.aggregate({
+      _count: { id: true }
+    });
+    const hexStats = await prisma.hex.aggregate({
+      _count: { id: true }
+    });
+    const gangStats = await prisma.gang.aggregate({
+      _count: { id: true }
+    });
+    const waferStats = await prisma.wafer.aggregate({
+      _count: { id: true }
+    });
+
+    res.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      database: prisma ? 'connected' : 'not connected',
+      mode: 'OpenClaw Agents',
+      stats: {
+        totalAgents: stats._count.id,
+        totalHexes: hexStats._count.id,
+        totalGangs: gangStats._count.id,
+        totalWafers: waferStats._count.id
+      }
+    });
+  };
+
+  app.get('/health', healthHandler);
+  app.get('/api/health', healthHandler);
+
+  // API Routes
+  app.use('/api/bots', botLimiter, agentRoutes);        // Original bot API
+  app.use('/api/agents', agentRoutes);                  // Alias for frontend compatibility
+  app.use('/api/hexes', botLimiter, hexRoutes);
+  app.use('/api/leaderboard', leaderboardRoutes);
+  app.use('/api/stats', statsRoutes);
+  app.use('/api/wafers', waferRoutes);
+  app.use('/api/gangs', gangRoutes);
+  app.use('/api/wallet', walletRoutes);
+
+  return app;
+}
+
+export async function runStartupChecks(): Promise<void> {
+  console.log('\n🔍 Running startup checks...\n');
+
+  // Check AI Provider
+  const aiStatus = await checkAIProvider();
+  console.log(`🤖 AI Provider: ${aiStatus.provider.toUpperCase()}`);
+  console.log(`   Status: ${aiStatus.message}`);
+  console.log(`   API Key: ${aiStatus.hasApiKey ? '✅ Configured' : '❌ Missing'}\n`);
+
+  // Environment summary
+  console.log('📋 Environment Configuration:');
+  console.log(`   PORT: ${process.env.PORT || 3001}`);
+  console.log(`   FRONTEND_URL: ${process.env.FRONTEND_URL || 'http://localhost:3000'}`);
+  console.log(`   DATABASE: ${process.env.DATABASE_URL?.includes('postgresql') ? 'PostgreSQL' : 'SQLite'}`);
+  console.log(`   AI_PROVIDER: ${process.env.AI_PROVIDER || 'glm (default)'}`);
+  console.log(`   GLM_API_KEY: ${process.env.GLM_API_KEY ? '✅ Set' : '❌ Not set'}\n`);
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,32 +1,9 @@
-// Load environment variables FIRST (before any other imports)
-import dotenv from 'dotenv';
-import path from 'path';
-
-// Explicitly load .env from backend directory
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
-
-// Debug: Log environment (remove in production)
-console.log('[ENV] Loading from:', path.resolve(__dirname, '../.env'));
-console.log('[ENV] GLM_API_KEY exists:', !!process.env.GLM_API_KEY);
-
-import express from 'express';
-import cors from 'cors';
-import helmet from 'helmet';
-import rateLimit from 'express-rate-limit';
-import { PrismaClient } from '@prisma/client';
 import { createServer } from 'http';
 import { Server as SocketIOServer } from 'socket.io';
-import agentRoutes from './api/bots';
-import hexRoutes from './api/hexes';
-import leaderboardRoutes from './api/leaderboard';
-import statsRoutes from './api/stats';
-import waferRoutes from './api/wafers';
-import gangRoutes from './api/gangs';
-import walletRoutes from './api/wallet';
-import { checkAIProvider } from './services/aiProvider';
+import { createApp, runStartupChecks } from './app';
+import { setSocketServer } from './realtime';
 
-const prisma = new PrismaClient();
-const app = express();
+const app = createApp();
 const httpServer = createServer(app);
 const io = new SocketIOServer(httpServer, {
   cors: {
@@ -35,82 +12,7 @@ const io = new SocketIOServer(httpServer, {
   }
 });
 
-// CORS - Allow all origins for development
-app.use(cors({
-  origin: '*',
-  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'X-OpenClaw-Bot', 'X-OpenClaw-Bot-Secret']
-}));
-
-// Security Middleware (configured to work with CORS)
-app.use(helmet({
-  crossOriginResourcePolicy: { policy: 'cross-origin' },
-  crossOriginEmbedderPolicy: false,
-  contentSecurityPolicy: false
-}));
-
-// Rate Limiting
-const limiter = rateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 100, // 100 requests per minute per IP
-  message: {
-    success: false,
-    error: 'Too many requests, please try again later.'
-  }
-});
-
-// Stricter rate limit for bot operations
-const botLimiter = rateLimit({
-  windowMs: 1 * 60 * 1000, // 1 minute
-  max: 30, // 30 requests per minute for bot operations
-  message: {
-    success: false,
-    error: 'Bot rate limit exceeded. Please slow down.'
-  }
-});
-
-app.use(limiter);
-
-app.use(express.json({ limit: '10mb' }));
-
-// Health check
-app.get('/health', async (req, res) => {
-  const stats = await prisma.agent.aggregate({
-    _count: { id: true }
-  });
-  const hexStats = await prisma.hex.aggregate({
-    _count: { id: true }
-  });
-  const gangStats = await prisma.gang.aggregate({
-    _count: { id: true }
-  });
-  const waferStats = await prisma.wafer.aggregate({
-    _count: { id: true }
-  });
-
-  res.json({
-    status: 'ok',
-    timestamp: new Date().toISOString(),
-    database: prisma ? 'connected' : 'not connected',
-    mode: 'OpenClaw Agents',
-    stats: {
-      totalAgents: stats._count.id,
-      totalHexes: hexStats._count.id,
-      totalGangs: gangStats._count.id,
-      totalWafers: waferStats._count.id
-    }
-  });
-});
-
-// API Routes
-app.use('/api/bots', botLimiter, agentRoutes);        // Original bot API
-app.use('/api/agents', agentRoutes);                  // Alias for frontend compatibility
-app.use('/api/hexes', botLimiter, hexRoutes);
-app.use('/api/leaderboard', leaderboardRoutes);
-app.use('/api/stats', statsRoutes);
-app.use('/api/wafers', waferRoutes);
-app.use('/api/gangs', gangRoutes);
-app.use('/api/wallet', walletRoutes);
+setSocketServer(io);
 
 // WebSocket connection
 io.on('connection', (socket) => {
@@ -131,50 +33,13 @@ io.on('connection', (socket) => {
   });
 });
 
-// Emit socket events helper
-export const emitHexUpdate = (event: string, data: any) => {
-  io.to('hex-updates').emit(event, data);
-};
-
-export const emitWaferUpdate = (event: string, data: any) => {
-  io.to('wafer-updates').emit(event, data);
-};
-
-// Check AI provider on startup
-async function startupChecks() {
-  console.log('\n🔍 Running startup checks...\n');
-  
-  // Check AI Provider
-  const aiStatus = await checkAIProvider();
-  console.log(`🤖 AI Provider: ${aiStatus.provider.toUpperCase()}`);
-  console.log(`   Status: ${aiStatus.message}`);
-  console.log(`   API Key: ${aiStatus.hasApiKey ? '✅ Configured' : '❌ Missing'}\n`);
-  
-  // Environment summary
-  console.log('📋 Environment Configuration:');
-  console.log(`   PORT: ${PORT}`);
-  console.log(`   FRONTEND_URL: ${process.env.FRONTEND_URL || 'http://localhost:3000'}`);
-  console.log(`   DATABASE: ${process.env.DATABASE_URL?.includes('postgresql') ? 'PostgreSQL' : 'SQLite'}`);
-  console.log(`   AI_PROVIDER: ${process.env.AI_PROVIDER || 'glm (default)'}`);
-  console.log(`   GLM_API_KEY: ${process.env.GLM_API_KEY ? '✅ Set' : '❌ Not set'}\n`);
-}
-
 // Start server
 const PORT = process.env.PORT || 3001;
 httpServer.listen(Number(PORT), '0.0.0.0', async () => {
   console.log(`🦞 ClawQuest API running on port ${PORT}`);
   console.log(`🌐 Server accessible at: http://0.0.0.0:${PORT}`);
   console.log(`🤖 Mode: OpenClaw Agents\n`);
-  
+
   // Run startup checks
-  await startupChecks();
-});
-
-// Export socket.io instance for use in routes
-export { io };
-
-// Graceful shutdown
-process.on('SIGTERM', async () => {
-  await prisma.$disconnect();
-  process.exit(0);
+  await runStartupChecks();
 });

--- a/backend/src/realtime.ts
+++ b/backend/src/realtime.ts
@@ -1,0 +1,25 @@
+import type { Server as SocketIOServer } from 'socket.io';
+
+type SocketServer = Pick<SocketIOServer, 'to'>;
+
+let socketServer: SocketServer | null = null;
+
+export function setSocketServer(server: SocketServer): void {
+  socketServer = server;
+}
+
+function emitToChannel(channel: string, event: string, payload: unknown): void {
+  if (!socketServer) {
+    return;
+  }
+
+  socketServer.to(channel).emit(event, payload);
+}
+
+export function emitHexUpdate(event: string, payload: unknown): void {
+  emitToChannel('hex-updates', event, payload);
+}
+
+export function emitWaferUpdate(event: string, payload: unknown): void {
+  emitToChannel('wafer-updates', event, payload);
+}

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/index" }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Make the backend runnable both as a long-running server (with Socket.IO) and as a Vercel serverless function by extracting the Express app into a reusable factory.
- Ensure realtime emits are safe when running serverless (no Socket.IO instance) and keep local socket functionality for the standalone server.
- Provide a consistent health endpoint and startup checks for easier deployment diagnostics.

### Description
- Extract Express configuration into `backend/src/app.ts` with `createApp()` and add `runStartupChecks()` and `/health` + `/api/health` handlers.
- Add a serverless entrypoint `backend/api/index.ts` and `backend/vercel.json` rewrite so `/api/*` routes are handled by the serverless function using `serverless-http`.
- Introduce `backend/src/realtime.ts` with `setSocketServer()` and `emitHexUpdate()`/`emitWaferUpdate()` helpers, and replace direct `io` emits in route files (`agents`, `gangs`, `hexes`) to use the helper so emits are no-ops in serverless.
- Update `backend/src/index.ts` to use `createApp()`, initialize Socket.IO only in the long-running server process, and call `setSocketServer(io)` so realtime works when running the server locally.
- Add `serverless-http` to `backend/package.json` and update `package-lock.json` to include the new dependency.

### Testing
- Ran `cd backend && npm install --package-lock-only`, which completed successfully (no vulnerabilities reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69887206e140832d9c0287b56371a8b7)