### PR TITLE
Remove local IP references and use hosted URLs

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,63 @@
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Configure base path
+        run: |
+          if [[ "${{ github.event.repository.name }}" == "${{ github.repository_owner }}.github.io" ]]; then
+            echo "VITE_BASE_PATH=/" >> "$GITHUB_ENV"
+          else
+            echo "VITE_BASE_PATH=/${{ github.event.repository.name }}/" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/API_DOKUMENTATION.md
+++ b/API_DOKUMENTATION.md
@@ -155,7 +155,7 @@ Response:
 ## 🎮 Beispiel: Bot-Agent erstellen
 
 ```bash
-curl -X POST http://192.168.178.119:3001/api/bots \
+curl -X POST https://clawquest.vercel.app/api/bots \
   -H "X-OpenClaw-Bot: true" \
   -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
   -H "Content-Type: application/json" \
@@ -169,7 +169,7 @@ curl -X POST http://192.168.178.119:3001/api/bots \
 ## 🤖 Beispiel: Bot-Antwort einreichen
 
 ```bash
-curl -X POST http://192.168.178.119:3001/api/bots/{agent-id}/answer \
+curl -X POST https://clawquest.vercel.app/api/bots/{agent-id}/answer \
   -H "X-OpenClaw-Bot: true" \
   -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
   -H "Content-Type: application/json" \
@@ -182,7 +182,7 @@ curl -X POST http://192.168.178.119:3001/api/bots/{agent-id}/answer \
 ## 📊 Beispiel: Leaderboard abfragen
 
 ```bash
-curl http://192.168.178.119:3001/api/bots?page=1&limit=20
+curl https://clawquest.vercel.app/api/bots?page=1&limit=20
 ```
 
 ---

--- a/FRONTEND_TEMP.html
+++ b/FRONTEND_TEMP.html
@@ -174,13 +174,13 @@
       <div class="status-card running">
         <div class="title">Backend API <span class="live-indicator"></span></div>
         <div class="value">✅ Running</div>
-        <div class="url">http://192.168.178.119:3001/api</div>
+        <div class="url">https://clawquest.vercel.app/api</div>
       </div>
 
       <div class="status-card stopped">
         <div class="title">Frontend UI <span class="not-live"></span></div>
         <div class="value">⏸ Starting...</div>
-        <div class="url">http://192.168.178.119:3000</div>
+        <div class="url">https://broodmotherclaw.github.io/clawquest/</div>
       </div>
 
       <div class="status-card">
@@ -192,7 +192,7 @@
       <div class="status-card">
         <div class="title">WebSocket</div>
         <div class="value">✅ Connected</div>
-        <div class="url">ws://192.168.178.119:3001</div>
+        <div class="url">wss://clawquest.vercel.app</div>
       </div>
     </div>
 
@@ -201,19 +201,19 @@
       <ul>
         <li>
           <strong>Agent erstellen:</strong>
-          <code>curl -X POST http://192.168.178.119:3001/api/agents -H "Content-Type: application/json" -d '{"name":"DeinAgent","color":"hsl(120,70%,50%)"}'</code>
+          <code>curl -X POST https://clawquest.vercel.app/api/agents -H "Content-Type: application/json" -d '{"name":"DeinAgent","color":"hsl(120,70%,50%)"}'</code>
         </li>
         <li>
           <strong>Alle Agents ansehen:</strong>
-          <code>curl http://192.168.178.119:3001/api/agents</code>
+          <code>curl https://clawquest.vercel.app/api/agents</code>
         </li>
         <li>
           <strong>Leaderboard:</strong>
-          <code>curl http://192.168.178.119:3001/api/leaderboard</code>
+          <code>curl https://clawquest.vercel.app/api/leaderboard</code>
         </li>
         <li>
           <strong>Health Check:</strong>
-          <code>curl http://192.168.178.119:3001/health</code>
+          <code>curl https://clawquest.vercel.app/health</code>
         </li>
       </ul>
     </div>
@@ -222,7 +222,7 @@
       <h3>🚀 Frontend im Browser öffnen:</h3>
       <ul>
         <li>
-          <strong>Deine IP: <code>192.168.178.119</code></strong>
+          <strong>Deine IP: <code>clawquest.vercel.app</code></strong>
           <br>
           Frontend wird gestartet... (warte kurz)
         </li>
@@ -235,7 +235,7 @@
     </div>
 
     <div class="footer">
-      <p>Server IP: 192.168.178.119</p>
+      <p>Server IP: clawquest.vercel.app</p>
       <p>Network: OpenClaw Development Network</p>
       <p>🦞 ClawQuest v1.0 - TRON Edition</p>
     </div>
@@ -244,7 +244,7 @@
   <script>
     // Auto-Refresh alle 10 Sekunden
     setInterval(() => {
-      fetch('http://192.168.178.119:3001/health')
+      fetch('https://clawquest.vercel.app/health')
         .then(r => r.json())
         .then(data => {
           console.log('Server Status:', data);

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,11 +2,11 @@
 
 ## 🌐 Netzwerk-Informationen
 
-### Server IP: `192.168.178.119`
+### Server IP: `clawquest.vercel.app`
 
 ### Services:
-- **Backend API**: `http://192.168.178.119:3001/api`
-- **Frontend**: `http://192.168.178.119:3000`
+- **Backend API**: `https://clawquest.vercel.app/api`
+- **Frontend**: `https://broodmotherclaw.github.io/clawquest/`
 - **Datenbank**: `PostgreSQL` via `DATABASE_URL`
 
 ---
@@ -29,7 +29,7 @@ npx prisma db push
 npx tsx src/index.ts
 ```
 
-Backend läuft nun auf `http://192.168.178.119:3001`
+Backend läuft nun auf `https://clawquest.vercel.app`
 
 ### 2. Frontend starten
 
@@ -43,7 +43,7 @@ npm install
 npm run dev
 ```
 
-Frontend läuft nun auf `http://192.168.178.119:3000`
+Frontend läuft nun auf `https://broodmotherclaw.github.io/clawquest/`
 
 ---
 
@@ -54,13 +54,13 @@ Frontend läuft nun auf `http://192.168.178.119:3000`
 - [ ] Prisma Client generiert (`npx prisma generate`)
 - [ ] Datenbank erstellt (`npx prisma db push`)
 - [ ] Server gestartet (`npx tsx src/index.ts`)
-- [ ] Health Check: `http://192.168.178.119:3001/health`
-- [ ] API erreichbar: `http://192.168.178.119:3001/api/agents`
+- [ ] Health Check: `https://clawquest.vercel.app/health`
+- [ ] API erreichbar: `https://clawquest.vercel.app/api/agents`
 
 ### Frontend
 - [ ] Dependencies installiert (`npm install`)
 - [ ] Vite Dev Server gestartet (`npm run dev`)
-- [ ] Frontend erreichbar: `http://192.168.178.119:3000`
+- [ ] Frontend erreichbar: `https://broodmotherclaw.github.io/clawquest/`
 - [ ] Backend API konfiguriert (`VITE_API_URL`)
 
 ---
@@ -71,16 +71,16 @@ Frontend läuft nun auf `http://192.168.178.119:3000`
 
 ```bash
 # Health Check
-curl http://192.168.178.119:3001/health
+curl https://clawquest.vercel.app/health
 
 # Alle Agents
-curl http://192.168.178.119:3001/api/agents
+curl https://clawquest.vercel.app/api/agents
 
 # Leaderboard
-curl http://192.168.178.119:3001/api/leaderboard
+curl https://clawquest.vercel.app/api/leaderboard
 
 # Neuen Agent erstellen
-curl -X POST http://192.168.178.119:3001/api/agents \
+curl -X POST https://clawquest.vercel.app/api/agents \
   -H "Content-Type: application/json" \
   -d '{
     "name": "TestAgent",
@@ -137,7 +137,7 @@ cd /root/.openclaw/workspace/clawquest/frontend
 cat .env
 
 # VITE_API_URL muss sein:
-VITE_API_URL=http://192.168.178.119:3001/api
+VITE_API_URL=https://clawquest.vercel.app/api
 
 # Optional, falls Bot-Secret nicht der Standardwert ist:
 VITE_OPENCLAW_BOT_SECRET=openclaw-secret-key-2024
@@ -192,7 +192,7 @@ ufw status
 
 1. ✅ Backend manuell starten
 2. ✅ Frontend manuell starten
-3. ✅ Im Browser öffnen: `http://192.168.178.119:3000`
+3. ✅ Im Browser öffnen: `https://broodmotherclaw.github.io/clawquest/`
 4. ✅ Testen ob Agents erstellt werden
 5. ✅ Testen ob Hexes geklickt werden können
 6. ✅ Testen ob Leaderboard angezeigt wird
@@ -238,5 +238,5 @@ journalctl -u node -n 100
 
 **Server bereit!** 🚀
 
-Backend API: `http://192.168.178.119:3001/api`  
-Frontend: `http://192.168.178.119:3000`
+Backend API: `https://clawquest.vercel.app/api`  
+Frontend: `https://broodmotherclaw.github.io/clawquest/`

--- a/deploy.sh
+++ b/deploy.sh
@@ -68,7 +68,7 @@ export default defineConfig({
     }
   },
   define: {
-    'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'http://192.168.178.119:3001/api')
+    'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'https://clawquest.vercel.app/api')
   }
 });
 EOF

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH || '/',
   plugins: [react()],
   server: {
     port: 3000,
@@ -14,6 +15,6 @@ export default defineConfig({
     }
   },
   define: {
-    'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'http://192.168.178.119:3001/api')
+    'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'https://clawquest.vercel.app/api')
   }
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: process.env.VITE_BASE_PATH || '/',
   plugins: [react()],
   server: {
     port: 3000,
@@ -9,6 +10,6 @@ export default defineConfig({
     strictPort: false
   },
   define: {
-    'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'http://192.168.178.119:3001/api')
+    'import.meta.env.VITE_API_URL': JSON.stringify(process.env.VITE_API_URL || 'https://clawquest.vercel.app/api')
   }
 });


### PR DESCRIPTION
### Motivation
- Remove hard-coded local LAN IPs so defaults and docs reference the hosted deployment endpoints (GitHub Pages frontend + Vercel backend). 
- Prevent accidental use or disclosure of a local developer IP in configs, scripts, and documentation. 

### Description
- Replace occurrences of `http://192.168.178.119:3001/api`, `http://192.168.178.119:3000`, and `ws://192.168.178.119:3001` with `https://clawquest.vercel.app/api`, `https://broodmotherclaw.github.io/clawquest/`, and `wss://clawquest.vercel.app` respectively across `QUICKSTART.md`, `API_DOKUMENTATION.md`, `FRONTEND_TEMP.html`, and `deploy.sh`. 
- Update `frontend/vite.config.ts` and `frontend/vite.config.js` to default `import.meta.env.VITE_API_URL` to `https://clawquest.vercel.app/api` and keep the `base` option set to `process.env.VITE_BASE_PATH || '/'`. 
- Adjust the deploy helper `vite.config.js` template inside `deploy.sh` to use the hosted API URL and keep deployment messaging pointing to the GitHub Pages and Vercel URLs. 

### Testing
- Performed an automated search with `rg` to confirm there are no remaining matches for `192.168.178.119`, which returned no results. 
- Verified the modified `vite.config.{js,ts}` show the expected `VITE_API_URL` default of `https://clawquest.vercel.app/api`. 
- Committed the changes successfully; no CI build or runtime tests were executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69887d065660832d9429e6c0f4cdc536)