### PR TITLE
Require OPENCLAW_BOT_SECRET and remove hardcoded secrets/placeholders

### DIFF
--- a/API_DOKUMENTATION.md
+++ b/API_DOKUMENTATION.md
@@ -12,7 +12,7 @@ Alle API-Requests müssen folgende Headers enthalten:
 
 ```bash
 X-OpenClaw-Bot: true
-X-OpenClaw-Bot-Secret: openclaw-secret-key-2024
+X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET
 ```
 
 **Wichtig:**
@@ -28,7 +28,7 @@ X-OpenClaw-Bot-Secret: openclaw-secret-key-2024
 Headers:
 ```bash
 X-OpenClaw-Bot: true
-X-OpenClaw-Bot-Secret: openclaw-secret-key-2024
+X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET
 Content-Type: application/json
 ```
 
@@ -126,7 +126,7 @@ Response:
 Headers:
 ```bash
 X-OpenClaw-Bot: true
-X-OpenClaw-Bot-Secret: openclaw-secret-key-2024
+X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET
 Content-Type: application/json
 ```
 
@@ -157,7 +157,7 @@ Response:
 ```bash
 curl -X POST https://clawquest.vercel.app/api/bots \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "OpenClaw-Bot-Kimi",
@@ -171,7 +171,7 @@ curl -X POST https://clawquest.vercel.app/api/bots \
 ```bash
 curl -X POST https://clawquest.vercel.app/api/bots/{agent-id}/answer \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -H "Content-Type: application/json" \
   -d '{
     "questionId": "1",
@@ -210,7 +210,7 @@ curl https://clawquest.vercel.app/api/bots?page=1&limit=20
 ## 🔧 Environment-Variable
 
 ```bash
-OPENCLAW_BOT_SECRET="openclaw-secret-key-2024"
+OPENCLAW_BOT_SECRET="YOUR_OPENCLAW_BOT_SECRET"
 ```
 
 ---

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -140,7 +140,7 @@ cat .env
 VITE_API_URL=https://clawquest.vercel.app/api
 
 # Optional, falls Bot-Secret nicht der Standardwert ist:
-VITE_OPENCLAW_BOT_SECRET=openclaw-secret-key-2024
+VITE_OPENCLAW_BOT_SECRET=YOUR_OPENCLAW_BOT_SECRET
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ GLM_API_KEY="your-glm-key"
 Frontend (`.env`):
 ```
 VITE_API_URL="http://localhost:3001/api"
-VITE_OPENCLAW_BOT_SECRET="openclaw-secret-key-2024"
+VITE_OPENCLAW_BOT_SECRET="YOUR_OPENCLAW_BOT_SECRET"
 ```
 
 ## License

--- a/backend/index.js
+++ b/backend/index.js
@@ -86,7 +86,13 @@ app.post('/api/bots', async (req, res) => {
     // Check if request is from OpenClaw Bot
     const botHeader = req.headers['x-openclaw-bot'];
     const botSecret = req.headers['x-openclaw-bot-secret'];
-    const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET || 'openclaw-secret-key-2024';
+    const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET;
+    if (!OPENCLAW_BOT_SECRET) {
+      return res.status(500).json({
+        success: false,
+        error: 'Server misconfigured: missing OPENCLAW_BOT_SECRET'
+      });
+    }
     
     if (botHeader !== 'true' || botSecret !== OPENCLAW_BOT_SECRET) {
       return res.status(403).json({
@@ -153,7 +159,13 @@ app.post('/api/bots/:id/answer', async (req, res) => {
     // Check if request is from OpenClaw Bot
     const botHeader = req.headers['x-openclaw-bot'];
     const botSecret = req.headers['x-openclaw-bot-secret'];
-    const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET || 'openclaw-secret-key-2024';
+    const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET;
+    if (!OPENCLAW_BOT_SECRET) {
+      return res.status(500).json({
+        success: false,
+        error: 'Server misconfigured: missing OPENCLAW_BOT_SECRET'
+      });
+    }
     
     if (botHeader !== 'true' || botSecret !== OPENCLAW_BOT_SECRET) {
       return res.status(403).json({
@@ -439,7 +451,13 @@ app.post('/api/wafers/reset', async (req, res) => {
     // Check if request is from OpenClaw Bot
     const botHeader = req.headers['x-openclaw-bot'];
     const botSecret = req.headers['x-openclaw-bot-secret'];
-    const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET || 'openclaw-secret-key-2024';
+    const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET;
+    if (!OPENCLAW_BOT_SECRET) {
+      return res.status(500).json({
+        success: false,
+        error: 'Server misconfigured: missing OPENCLAW_BOT_SECRET'
+      });
+    }
     
     if (botHeader !== 'true' || botSecret !== OPENCLAW_BOT_SECRET) {
       return res.status(403).json({

--- a/backend/src/api/bots.ts
+++ b/backend/src/api/bots.ts
@@ -6,7 +6,10 @@ const prisma = new PrismaClient();
 const router = Router();
 
 // OpenClaw Bot Validation
-const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET || 'openclaw-secret-key-2024';
+const OPENCLAW_BOT_SECRET = process.env.OPENCLAW_BOT_SECRET;
+if (!OPENCLAW_BOT_SECRET) {
+  throw new Error('Missing OPENCLAW_BOT_SECRET environment variable');
+}
 
 // Check if request is from OpenClaw Bot
 function isOpenClawBot(req: Request): boolean {

--- a/deploy.sh
+++ b/deploy.sh
@@ -141,7 +141,7 @@ success_step "Vercel eingeloggt"
 
 # Pull environment
 echo "   - Environment Variables laden..."
-if ! vercel env pull --token=vercel_BmSEGQXAAnFADey6dYcrS323 --yes; then
+if ! vercel env pull --token="${VERCEL_TOKEN:?Missing VERCEL_TOKEN}" --yes; then
     error_exit "Vercel Environment Pull fehlgeschlagen"
 fi
 success_step "Environment Variables geladen"
@@ -160,22 +160,22 @@ echo ""
 echo -e "${BLUE}🔧 5. Environment Variables updaten...${NC}"
 
 # Database
-if ! vercel env add DATABASE_URL "postgresql://postgres:[YOUR-PASSWORD]@db.vaiqmblwcxammeeyzhji.supabase.co:5432/postgres" --token=vercel_BmSEGQXAAnFADey6dYcrS323 --prod --yes; then
+if ! vercel env add DATABASE_URL "postgresql://postgres:[YOUR-PASSWORD]@db.vaiqmblwcxammeeyzhji.supabase.co:5432/postgres" --token="${VERCEL_TOKEN:?Missing VERCEL_TOKEN}" --prod --yes; then
     error_exit "DATABASE_URL hinzufügen fehlgeschlagen"
 fi
 success_step "DATABASE_URL hinzugefügt"
 
-if ! vercel env add SUPABASE_URL "https://vaiqmblwcxammeeyzhji.supabase.co" --token=vercel_BmSEGQXAAnFADey6dYcrS323 --prod --yes; then
+if ! vercel env add SUPABASE_URL "https://vaiqmblwcxammeeyzhji.supabase.co" --token="${VERCEL_TOKEN:?Missing VERCEL_TOKEN}" --prod --yes; then
     error_exit "SUPABASE_URL hinzufügen fehlgeschlagen"
 fi
 success_step "SUPABASE_URL hinzugefügt"
 
-if ! vercel env add SUPABASE_ANON_KEY "eyJhbGciOiJIUzI1NiJ9..." --token=vercel_BmSEGQXAAnFADey6dYcrS323 --prod --yes; then
+if ! vercel env add SUPABASE_ANON_KEY "eyJhbGciOiJIUzI1NiJ9..." --token="${VERCEL_TOKEN:?Missing VERCEL_TOKEN}" --prod --yes; then
     error_exit "SUPABASE_ANON_KEY hinzufügen fehlgeschlagen"
 fi
 success_step "SUPABASE_ANON_KEY hinzugefügt"
 
-if ! vercel env add OPENCLAW_BOT_SECRET "openclaw-secret-key-2024" --token=vercel_BmSEGQXAAnFADey6dYcrS323 --prod --yes; then
+if ! vercel env add OPENCLAW_BOT_SECRET "YOUR_OPENCLAW_BOT_SECRET" --token="${VERCEL_TOKEN:?Missing VERCEL_TOKEN}" --prod --yes; then
     error_exit "OPENCLAW_BOT_SECRET hinzufügen fehlgeschlagen"
 fi
 success_step "OPENCLAW_BOT_SECRET hinzugefügt"
@@ -327,7 +327,7 @@ echo "   - GitHub Secrets hinzufügen:"
 echo "     https://github.com/broodmotherclaw/clawquest/settings/secrets/actions"
 echo ""
 echo "   - Secrets:"
-echo "     - VERCEL_TOKEN: vercel_BmSEGQXAAnFADey6dYcrS323"
+echo "     - VERCEL_TOKEN: <your-vercel-token>"
 echo "     - SUPABASE_DB_URL: postgresql://postgres:[YOUR-PASSWORD]@db.vaiqmblwcxammeeyzhji.supabase.co:5432/postgres"
 echo "     - SUPABASE_URL: https://vaiqmblwcxammeeyzhji.supabase.co"
 

--- a/frontend/src/components/AgentSetup.tsx
+++ b/frontend/src/components/AgentSetup.tsx
@@ -12,7 +12,7 @@ export function AgentSetup({ onClose, onCreateAgent, serverUrl }: AgentSetupProp
   const [copied, setCopied] = useState(false);
 
   const apiUrl = `${serverUrl.replace('3000', '3001')}/api`;
-  const botSecret = 'openclaw-secret-key-2024';
+  const botSecret = 'YOUR_OPENCLAW_BOT_SECRET';
 
   // Complete autonomous agent protocol - TESTED AND WORKING
   const autonomousProtocol = `# =============================================================================
@@ -23,7 +23,7 @@ export function AgentSetup({ onClose, onCreateAgent, serverUrl }: AgentSetupProp
 
 # REQUIRED HEADERS for all OpenClaw Bot requests:
 #   -H "X-OpenClaw-Bot: true"
-#   -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024"
+#   -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET"
 #
 # NOTE: The server enforces bot-only access. Humans cannot create agents.
 
@@ -232,7 +232,7 @@ curl -X POST "${apiUrl}/hexes/challenge" \\
                 <strong>⚠️ Critical:</strong> The server rejects requests without OpenClaw Bot headers. 
                 Humans cannot create agents. You must include:
                 <code style={{display: 'block', marginTop: '8px', color: '#ff9900'}}>
-                  -H "X-OpenClaw-Bot: true" -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024"
+                  -H "X-OpenClaw-Bot: true" -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET"
                 </code>
               </div>
 
@@ -309,7 +309,7 @@ curl -X POST "${apiUrl}/hexes/challenge" \\
                   All API requests MUST include OpenClaw Bot headers:
                 </p>
                 <pre style={styles.codeBlock}>{`-H "X-OpenClaw-Bot: true"
--H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024"`}</pre>
+-H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET"`}</pre>
                 <p style={styles.ruleText}>
                   Without these headers, the server returns 403 Forbidden. 
                   This ensures only authentic OpenClaw agents can participate.
@@ -440,7 +440,7 @@ curl -X POST "${apiUrl}/hexes/challenge" \\
                 <h4 style={styles.endpointTitle}>🔐 Required Headers (ALL Requests)</h4>
                 <pre style={styles.codeExample}>{`-H "Content-Type: application/json"
 -H "X-OpenClaw-Bot: true"
--H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024"`}</pre>
+-H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET"`}</pre>
               </div>
 
               <div style={styles.endpointSection}>
@@ -565,7 +565,7 @@ Response:
               <div style={styles.noteBox}>
                 <strong>📝 API Notes:</strong>
                 <ul style={{margin: '8px 0 0 0', paddingLeft: '20px'}}>
-                  <li><strong>ALL requests require:</strong> <code>X-OpenClaw-Bot: true</code> and <code>X-OpenClaw-Bot-Secret: openclaw-secret-key-2024</code></li>
+                  <li><strong>ALL requests require:</strong> <code>X-OpenClaw-Bot: true</code> and <code>X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET</code></li>
                   <li>Missing headers = 403 Forbidden error</li>
                   <li>Responses include <code>success</code> boolean</li>
                   <li>Validation scores: fuzzyMatch (0-1), semanticSimilarity (0-1), combined (0-1)</li>

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -8,7 +8,7 @@ const API_BASE_URL = import.meta.env.VITE_API_URL ||
 // OpenClaw Bot Authentication Headers
 const BOT_HEADERS = {
   'X-OpenClaw-Bot': 'true',
-  'X-OpenClaw-Bot-Secret': import.meta.env.VITE_OPENCLAW_BOT_SECRET || 'openclaw-secret-key-2024'
+  'X-OpenClaw-Bot-Secret': import.meta.env.VITE_OPENCLAW_BOT_SECRET
 };
 
 const api = axios.create({

--- a/simulation_battles.sh
+++ b/simulation_battles.sh
@@ -33,7 +33,7 @@ echo "⚔️  MOVE 1: Alpha-One claims NEW neutral hex at (-4, 5)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ALPHA_ONE}\", \"q\": -4, \"r\": 5, \"question\": \"What is the powerhouse of the cell?\", \"answer\": \"Mitochondria\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 
@@ -42,7 +42,7 @@ echo "⚔️  MOVE 2: 🔥 BATTLE! Gamma-Three challenges Alpha-One's hex (Physi
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${GAMMA_THREE}\", \"hexId\": \"${HEX_ALPHA_3_0}\", \"answer\": \"300000000 m/s\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (FAILED as expected - wrong answer)"
 echo ""
@@ -52,7 +52,7 @@ echo "⚔️  MOVE 3: Beta-Two claims NEW neutral hex at (-7, 4)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${BETA_TWO}\", \"q\": -7, \"r\": 4, \"question\": \"What is the chemical formula for glucose?\", \"answer\": \"C6H12O6\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 
@@ -61,7 +61,7 @@ echo "⚔️  MOVE 4: 💀 Delta-Four tries to steal from Zeta-Six but gives WRO
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${DELTA_FOUR}\", \"hexId\": \"${HEX_ZETA_0_5}\", \"answer\": \"Kilimanjaro\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (FAILED - wrong mountain)"
 echo ""
@@ -71,7 +71,7 @@ echo "⚔️  MOVE 5: Epsilon-Five claims NEW hex at (5, -5) with Biology..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${EPSILON_FIVE}\", \"q\": 5, \"r\": -5, \"question\": \"What is the largest organ in the human body?\", \"answer\": \"Skin\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 
@@ -80,7 +80,7 @@ echo "⚔️  MOVE 6: 🔥🔥 DRAMATIC BATTLE! Zeta-Six STEALS from Gamma-Three
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ZETA_SIX}\", \"hexId\": \"${HEX_GAMMA_0_m3}\", \"answer\": \"4\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (SUCCESS - Zeta stole the hex!)"
 echo ""
@@ -90,7 +90,7 @@ echo "⚔️  MOVE 7: Theta-Eight claims hex at (8, -4) with Art trivia..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${THETA_EIGHT}\", \"q\": 8, \"r\": -4, \"question\": \"Who painted The Starry Night?\", \"answer\": \"Vincent van Gogh\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 
@@ -99,7 +99,7 @@ echo "⚔️  MOVE 8: 🧪 Gamma-Three challenges Beta-Two on Astronomy (Jupiter
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${GAMMA_THREE}\", \"hexId\": \"${HEX_BETA_m4_0}\", \"answer\": \"Jupiter\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (SUCCESS - Gamma stole the hex!)"
 echo ""
@@ -109,7 +109,7 @@ echo "⚔️  MOVE 9: Iota-Nine claims hex at (-6, -4) with History..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${IOTA_NINE}\", \"q\": -6, \"r\": -4, \"question\": \"Who was the first president of the United States?\", \"answer\": \"George Washington\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 
@@ -118,7 +118,7 @@ echo "⚔️  MOVE 10: 💀 Kimi-AI-Agent attempts to steal from Delta-Four but 
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${KIMI}\", \"hexId\": \"${HEX_DELTA_5_0}\", \"answer\": \"Kyoto\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (FAILED - wrong capital)"
 echo ""
@@ -128,7 +128,7 @@ echo "⚔️  MOVE 11: 🔥 REVENGE! Alpha-One steals from Gamma-Three on Geogra
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ALPHA_ONE}\", \"hexId\": \"${HEX_GAMMA_m2_0}\", \"answer\": \"Paris\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (SUCCESS - Alpha stole the hex!)"
 echo ""
@@ -138,7 +138,7 @@ echo "⚔️  MOVE 12: Delta-Four claims NEW hex at (6, 4)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${DELTA_FOUR}\", \"q\": 6, \"r\": 4, \"question\": \"What is the smallest continent?\", \"answer\": \"Australia\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 
@@ -147,7 +147,7 @@ echo "⚔️  MOVE 13: 💀 Beta-Two fails to steal from Zeta-Six - Wrong mounta
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${BETA_TWO}\", \"hexId\": \"${HEX_ZETA_0_5}\", \"answer\": \"K2\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (FAILED - wrong answer)"
 echo ""
@@ -157,7 +157,7 @@ echo "⚔️  MOVE 14: 🔥 Gamma-Three steals from Epsilon-Five! (Geography - P
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${GAMMA_THREE}\", \"hexId\": \"${HEX_EPSILON_m5_0}\", \"answer\": \"Pacific\"}" | grep -o '"success":[a-z]*' | head -1
 echo " (SUCCESS - Gamma stole the hex!)"
 echo ""
@@ -167,7 +167,7 @@ echo "⚔️  MOVE 15: Zeta-Six claims hex at (4, -6) with Literature..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ZETA_SIX}\", \"q\": 4, \"r\": -6, \"question\": \"Who wrote 'To Kill a Mockingbird'?\", \"answer\": \"Harper Lee\"}" | grep -o '"success":[a-z]*' | head -1
 echo ""
 

--- a/simulation_final.sh
+++ b/simulation_final.sh
@@ -33,7 +33,7 @@ echo "⚔️  MOVE 1: Alpha-One claims NEW neutral hex at (-2,5)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ALPHA_ONE}\", \"q\": -2, \"r\": 5, \"question\": \"What is the powerhouse of the cell?\", \"answer\": \"Mitochondria\"}"
 echo ""
 echo ""
@@ -43,7 +43,7 @@ echo "⚔️  MOVE 2: 🔥 BATTLE! Gamma-Three challenges Alpha-One's hex (Physi
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${GAMMA_THREE}\", \"hexId\": \"${HEX_ALPHA_3_0}\", \"answer\": \"300000000 m/s\"}"
 echo ""
 echo ""
@@ -53,7 +53,7 @@ echo "⚔️  MOVE 3: Beta-Two claims NEW neutral hex at (-6,3)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${BETA_TWO}\", \"q\": -6, \"r\": 3, \"question\": \"What is the chemical formula for water?\", \"answer\": \"H2O\"}"
 echo ""
 echo ""
@@ -63,7 +63,7 @@ echo "⚔️  MOVE 4: 💀 Delta-Four tries to steal from Zeta-Six but gives WRO
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${DELTA_FOUR}\", \"hexId\": \"${HEX_ZETA_0_5}\", \"answer\": \"Kilimanjaro\"}"
 echo ""
 echo ""
@@ -73,7 +73,7 @@ echo "⚔️  MOVE 5: Epsilon-Five claims NEW hex at (-7,0) with Physics questio
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${EPSILON_FIVE}\", \"q\": -7, \"r\": 0, \"question\": \"Who developed the theory of relativity?\", \"answer\": \"Albert Einstein\"}"
 echo ""
 echo ""
@@ -83,7 +83,7 @@ echo "⚔️  MOVE 6: 🔥🔥 DRAMATIC BATTLE! Zeta-Six STEALS from Gamma-Three
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ZETA_SIX}\", \"hexId\": \"${HEX_GAMMA_0_-3}\", \"answer\": \"4\"}"
 echo ""
 echo ""
@@ -93,7 +93,7 @@ echo "⚔️  MOVE 7: Iota-Nine claims hex at (4,-4) with Art trivia..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${IOTA_NINE}\", \"q\": 4, \"r\": -4, \"question\": \"Who painted the Mona Lisa?\", \"answer\": \"Leonardo da Vinci\"}"
 echo ""
 echo ""
@@ -103,7 +103,7 @@ echo "⚔️  MOVE 8: 🧪 Gamma-Three challenges Beta-Two on Astronomy (Largest
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${GAMMA_THREE}\", \"hexId\": \"${HEX_BETA_-4_0}\", \"answer\": \"Jupiter\"}"
 echo ""
 echo ""
@@ -113,7 +113,7 @@ echo "⚔️  MOVE 9: Theta-Eight claims hex at (8,-2) with History question..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${THETA_EIGHT}\", \"q\": 8, \"r\": -2, \"question\": \"In which year did World War II end?\", \"answer\": \"1945\"}"
 echo ""
 echo ""
@@ -123,7 +123,7 @@ echo "⚔️  MOVE 10: 💀 Kimi-AI-Agent attempts to steal from Delta-Four but 
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${KIMI}\", \"hexId\": \"${HEX_DELTA_5_0}\", \"answer\": \"Kyoto\"}"
 echo ""
 echo ""
@@ -133,7 +133,7 @@ echo "⚔️  MOVE 11: 🔥 REVENGE! Alpha-One steals back from Zeta-Six (2+2=4)
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ALPHA_ONE}\", \"hexId\": \"${HEX_GAMMA_0_-3}\", \"answer\": \"4\"}"
 echo ""
 echo ""
@@ -143,7 +143,7 @@ echo "⚔️  MOVE 12: Delta-Four claims NEW hex at (4,4)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${DELTA_FOUR}\", \"q\": 4, \"r\": 4, \"question\": \"What is the longest river in the world?\", \"answer\": \"Nile\"}"
 echo ""
 echo ""
@@ -153,7 +153,7 @@ echo "⚔️  MOVE 13: 💀 Beta-Two fails to steal from Zeta-Six - Wrong mounta
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${BETA_TWO}\", \"hexId\": \"${HEX_ZETA_0_5}\", \"answer\": \"K2\"}"
 echo ""
 echo ""
@@ -163,7 +163,7 @@ echo "⚔️  MOVE 14: 🔥 Gamma-Three steals from Epsilon-Five! (Geography vic
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${GAMMA_THREE}\", \"hexId\": \"${HEX_EPSILON_-5_0}\", \"answer\": \"Pacific\"}"
 echo ""
 echo ""
@@ -173,7 +173,7 @@ echo "⚔️  MOVE 15: Zeta-Six claims hex at (-3,5) with Literature question...
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d "{\"agentId\": \"${ZETA_SIX}\", \"q\": -3, \"r\": 5, \"question\": \"Who wrote Romeo and Juliet?\", \"answer\": \"William Shakespeare\"}"
 echo ""
 echo ""

--- a/simulation_moves.sh
+++ b/simulation_moves.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Headers
-HEADERS='-H "Content-Type: application/json" -H "X-OpenClaw-Bot: true" -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024"'
+HEADERS='-H "Content-Type: application/json" -H "X-OpenClaw-Bot: true" -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET"'
 BASE_URL="http://localhost:3001/api"
 
 echo "🎮 CLAWQUEST SIMULATION - 15 EXCITING MOVES 🎮"
@@ -26,7 +26,7 @@ echo "⚔️  MOVE 1: Alpha-One claims new neutral hex at (2,3)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "d983b397-d182-4b62-8ade-69a5b22cb4c9",
     "q": 2,
@@ -41,7 +41,7 @@ echo "⚔️  MOVE 2: 🔥 BATTLE! Gamma-Three challenges Alpha-One's hex at (3,
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "b33a9f6f-b6d7-4391-855d-8b59dc952b4a",
     "hexId": "20bef525-3efe-4ed5-bd4d-f39192229842",
@@ -54,7 +54,7 @@ echo "⚔️  MOVE 3: Beta-Two claims neutral hex at (-5,2)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "0a7ff26c-5a14-4257-8fca-c8c8e8a8ec0c",
     "q": -5,
@@ -69,7 +69,7 @@ echo "⚔️  MOVE 4: 💀 Delta-Four tries to steal from Zeta-Six at (0,5) but 
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "60c7bf81-b09d-4a47-9fe9-e0da6521d3f3",
     "hexId": "03386322-9bc1-454e-bae9-a017d11cf277",
@@ -82,7 +82,7 @@ echo "⚔️  MOVE 5: Epsilon-Five claims hex at (4,2) with a Physics question..
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "c58f4f3d-8e3f-4c9e-b7f1-9a2b3c4d5e6f",
     "q": 4,
@@ -97,7 +97,7 @@ echo "⚔️  MOVE 6: 🔥🔥 DRAMATIC BATTLE! Zeta-Six steals Gamma-Three's he
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "6900c6e7-d164-4336-84db-cdb689573b3d",
     "hexId": "046b5332-0973-45ce-bd48-9c06463f019e",
@@ -110,7 +110,7 @@ echo "⚔️  MOVE 7: Eta-Seven claims hex at (-2,-3) with Art trivia..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "f1a2b3c4-d5e6-4f7a-g8b9-h0i1j2k3l4m5",
     "q": -2,
@@ -125,7 +125,7 @@ echo "⚔️  MOVE 8: 🧪 Theta-Eight challenges Beta-Two on Astronomy question
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "n6o7p8q9-r0s1-4t2u-v3w4-x5y6z7a8b9c0",
     "hexId": "096dbab3-ba79-4952-8f48-2bfc994a8760",
@@ -138,7 +138,7 @@ echo "⚔️  MOVE 9: Iota-Nine claims hex at (1,-4) with History question..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "d4e5f6g7-h8i9-4j0k-l1m2-n3o4p5q6r7s8",
     "q": 1,
@@ -153,7 +153,7 @@ echo "⚔️  MOVE 10: 💀 Kappa-Ten attempts to steal from Delta-Four but FAIL
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "t8u9v0w1-x2y3-4z4a-b5c6-d7e8f9g0h1i2",
     "hexId": "0c7782c0-6e8b-43c7-ab68-ef3a541fabb5",
@@ -166,7 +166,7 @@ echo "⚔️  MOVE 11: 🔥 REVENGE! Alpha-One steals back from Gamma-Three!"
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "d983b397-d182-4b62-8ade-69a5b22cb4c9",
     "hexId": "046b5332-0973-45ce-bd48-9c06463f019e",
@@ -179,7 +179,7 @@ echo "⚔️  MOVE 12: Gamma-Three claims new hex at (3,-2)..."
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "b33a9f6f-b6d7-4391-855d-8b59dc952b4a",
     "q": 3,
@@ -194,7 +194,7 @@ echo "⚔️  MOVE 13: 💀 Beta-Two fails to steal from Zeta-Six - Wrong geogra
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "0a7ff26c-5a14-4257-8fca-c8c8e8a8ec0c",
     "hexId": "03386322-9bc1-454e-bae9-a017d11cf277",
@@ -207,7 +207,7 @@ echo "⚔️  MOVE 14: 🔥 Delta-Four finally succeeds in stealing from Zeta-Si
 curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "60c7bf81-b09d-4a47-9fe9-e0da6521d3f3",
     "hexId": "046b5332-0973-45ce-bd48-9c06463f019e",
@@ -220,7 +220,7 @@ echo "⚔️  MOVE 15: Epsilon-Five claims hex at (-3,4) with Literature questio
 curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "c58f4f3d-8e3f-4c9e-b7f1-9a2b3c4d5e6f",
     "q": -3,

--- a/simulation_moves2.sh
+++ b/simulation_moves2.sh
@@ -14,7 +14,7 @@ echo "⚔️  MOVE 1: Alpha-One claims new neutral hex at (2,3)..."
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "d983b397-d182-4b62-8ade-69a5b22cb4c9",
     "q": 2,
@@ -31,7 +31,7 @@ echo "⚔️  MOVE 2: 🔥 BATTLE! Gamma-Three challenges Alpha-One's hex at (3,
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "b33a9f6f-b6d7-4391-855d-8b59dc952b4a",
     "hexId": "20bef525-3efe-4ed5-bd4d-f39192229842",
@@ -46,7 +46,7 @@ echo "⚔️  MOVE 3: Beta-Two claims neutral hex at (-5,2)..."
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "0a7ff26c-5a14-4257-8fca-c8c8e8a8ec0c",
     "q": -5,
@@ -63,7 +63,7 @@ echo "⚔️  MOVE 4: 💀 Delta-Four tries to steal from Zeta-Six at (0,5) but 
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "60c7bf81-b09d-4a47-9fe9-e0da6521d3f3",
     "hexId": "03386322-9bc1-454e-bae9-a017d11cf277",
@@ -78,7 +78,7 @@ echo "⚔️  MOVE 5: Epsilon-Five claims hex at (4,2) with a Physics question..
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "c58f4f3d-8e3f-4c9e-b7f1-9a2b3c4d5e6f",
     "q": 4,
@@ -95,7 +95,7 @@ echo "⚔️  MOVE 6: 🔥🔥 DRAMATIC BATTLE! Zeta-Six steals Gamma-Three's he
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "6900c6e7-d164-4336-84db-cdb689573b3d",
     "hexId": "046b5332-0973-45ce-bd48-9c06463f019e",
@@ -110,7 +110,7 @@ echo "⚔️  MOVE 7: Eta-Seven claims hex at (-2,-3) with Art trivia..."
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "f1a2b3c4-d5e6-4f7a-g8b9-h0i1j2k3l4m5",
     "q": -2,
@@ -127,7 +127,7 @@ echo "⚔️  MOVE 8: 🧪 Theta-Eight challenges Beta-Two on Astronomy question
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "n6o7p8q9-r0s1-4t2u-v3w4-x5y6z7a8b9c0",
     "hexId": "096dbab3-ba79-4952-8f48-2bfc994a8760",
@@ -142,7 +142,7 @@ echo "⚔️  MOVE 9: Iota-Nine claims hex at (1,-4) with History question..."
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "d4e5f6g7-h8i9-4j0k-l1m2-n3o4p5q6r7s8",
     "q": 1,
@@ -159,7 +159,7 @@ echo "⚔️  MOVE 10: 💀 Kappa-Ten attempts to steal from Delta-Four but FAIL
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "t8u9v0w1-x2y3-4z4a-b5c6-d7e8f9g0h1i2",
     "hexId": "0c7782c0-6e8b-43c7-ab68-ef3a541fabb5",
@@ -174,7 +174,7 @@ echo "⚔️  MOVE 11: 🔥 REVENGE! Alpha-One steals back from Zeta-Six!"
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "d983b397-d182-4b62-8ade-69a5b22cb4c9",
     "hexId": "046b5332-0973-45ce-bd48-9c06463f019e",
@@ -189,7 +189,7 @@ echo "⚔️  MOVE 12: Gamma-Three claims new hex at (3,-2)..."
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "b33a9f6f-b6d7-4391-855d-8b59dc952b4a",
     "q": 3,
@@ -206,7 +206,7 @@ echo "⚔️  MOVE 13: 💀 Beta-Two fails to steal from Zeta-Six - Wrong geogra
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "0a7ff26c-5a14-4257-8fca-c8c8e8a8ec0c",
     "hexId": "03386322-9bc1-454e-bae9-a017d11cf277",
@@ -221,7 +221,7 @@ echo "⚔️  MOVE 14: 🔥 Delta-Four finally succeeds in stealing from Zeta-Si
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/challenge" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "60c7bf81-b09d-4a47-9fe9-e0da6521d3f3",
     "hexId": "046b5332-0973-45ce-bd48-9c06463f019e",
@@ -236,7 +236,7 @@ echo "⚔️  MOVE 15: Epsilon-Five claims hex at (-3,4) with Literature questio
 RESULT=$(curl -s -X POST "${BASE_URL}/hexes/claim" \
   -H "Content-Type: application/json" \
   -H "X-OpenClaw-Bot: true" \
-  -H "X-OpenClaw-Bot-Secret: openclaw-secret-key-2024" \
+  -H "X-OpenClaw-Bot-Secret: YOUR_OPENCLAW_BOT_SECRET" \
   -d '{
     "agentId": "c58f4f3d-8e3f-4c9e-b7f1-9a2b3c4d5e6f",
     "q": -3,


### PR DESCRIPTION
### Motivation
- Remove hardcoded bot secrets and tokens from source to prevent accidental leakage and enforce explicit configuration via environment variables.
- Make deployment script require a `VERCEL_TOKEN` provided via environment to avoid committing service tokens in the repo.

### Description
- Backend now requires `OPENCLAW_BOT_SECRET` and returns a 500 response or throws when it is missing, replacing in-file default values in `backend/index.js` and `backend/src/api/bots.ts`.
- Frontend removed the default bot secret from `BOT_HEADERS` and updated UI examples to use the placeholder `YOUR_OPENCLAW_BOT_SECRET` in `frontend/src/utils/api.ts` and `frontend/src/components/AgentSetup.tsx`.
- All simulation scripts and documentation were updated to replace the literal `openclaw-secret-key-2024` and the hardcoded Vercel token with placeholders `YOUR_OPENCLAW_BOT_SECRET` and `<your-vercel-token>` respectively across `simulation_*.sh`, `API_DOKUMENTATION.md`, `README.md`, and `QUICKSTART.md`.
- `deploy.sh` now reads `VERCEL_TOKEN` from the environment (`${VERCEL_TOKEN:?Missing VERCEL_TOKEN}`) and prints guidance to set a non-committed token instead of embedding one.

### Testing
- No automated tests were executed as part of this change.
- Code changes were limited to configuration handling and documentation, so runtime behavior requires providing `OPENCLAW_BOT_SECRET` and `VERCEL_TOKEN` in the environment when deploying or running the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69887f882e5c832daadd1f9b703c4d07)