### PR TITLE
Fix pages artifact upload path

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: frontend/dist
+          path: docs
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- The GitHub Actions run failed with `tar: frontend/dist: Cannot open` because Vite is configured to output the build to `../docs`, so the artifact path in the workflow was incorrect.

### Description
- Update `.github/workflows/deploy-frontend.yml` to upload the Pages artifact from `docs` instead of `frontend/dist`.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698881667f08832dadd031185d5a21f8)