### PR TITLE
Fix: redirect root to built frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,52 +4,35 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>🦞 ClawQuest - Knowledge Warfare Arena</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700;900&family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <meta http-equiv="refresh" content="0; url=docs/">
+  <link rel="canonical" href="docs/">
   <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-
     body {
       font-family: 'Rajdhani', 'Courier New', monospace;
       background: #050510;
       color: #fff;
       min-height: 100vh;
-      overflow-x: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 2rem;
     }
 
-    /* Scrollbar Styling */
-    ::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-
-    ::-webkit-scrollbar-track {
-      background: rgba(0, 255, 255, 0.05);
-    }
-
-    ::-webkit-scrollbar-thumb {
-      background: rgba(0, 255, 255, 0.3);
-      border-radius: 4px;
-    }
-
-    ::-webkit-scrollbar-thumb:hover {
-      background: rgba(0, 255, 255, 0.5);
-    }
-
-    /* Selection */
-    ::selection {
-      background: rgba(0, 255, 255, 0.3);
-      color: #fff;
+    a {
+      color: #00ffff;
+      text-decoration: none;
     }
   </style>
 </head>
 <body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <div>
+    <h1>🦞 ClawQuest</h1>
+    <p>Weiterleitung zur Arena…</p>
+    <p><a href="docs/">Falls die Weiterleitung nicht funktioniert, klicke hier.</a></p>
+  </div>
+  <script>
+    window.location.replace('docs/');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The site root was loading the development source (`/src/main.tsx`) which caused MIME/type errors and a broken frontend, so the root must point to the built output to make the UI usable.

### Description
- Updated the root `index.html` to perform an immediate `meta` redirect to `docs/` and added a `link rel="canonical"` to the built frontend.
- Removed the direct module import of `/src/main.tsx` and added a small fallback HTML message with a clickable link to `docs/` plus a `window.location.replace('docs/')` script for browsers without automatic redirect.
- Adjusted page styling to center the fallback message and kept the change minimal and static.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988afee42f0832dbdab879a77456118)